### PR TITLE
Generate method takes eos_token_id

### DIFF
--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -400,36 +400,56 @@ class Llama(nn.Module):
         max_new_tokens: int,
         temperature=1.0,
         top_k: int | None = None,
-        eos_token_id: int | None = None,  # Add EOS token parameter
+        eos_token_id: int | None = None,
     ) -> Float[Tensor, "... pos"]:
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (b,t)) and complete
         the sequence max_new_tokens times, feeding the predictions back into the model each time.
         Most likely you'll want to make sure to be in model.eval() mode of operation for this.
         """
+        # Initialize not_completed mask for the batch
+        batch_size = idx.size(0)
+        not_completed = torch.ones(batch_size, dtype=torch.bool, device=idx.device)
+
         for _ in range(max_new_tokens):
+            # If all sequences are completed, stop early
+            if not not_completed.any():
+                break
+
             # if the sequence context is growing too long we must crop it at block_size
             idx_cond = (
                 idx if idx.size(1) <= self.config.block_size else idx[:, -self.config.block_size :]
             )
+
             # forward the model to get the logits for the index in the sequence
             logits, _ = self(idx_cond)
             # pluck the logits at the final step and scale by desired temperature
             logits = logits[:, -1, :] / temperature
+
             # optionally crop the logits to only the top k options
             if top_k is not None:
                 v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
                 logits[logits < v[:, [-1]]] = -float("Inf")
+
             # apply softmax to convert logits to (normalized) probabilities
             probs = F.softmax(logits, dim=-1)
+
             # sample from the distribution
             idx_next = torch.multinomial(probs, num_samples=1)
+
+            # Create a mask for selecting which sequences to update
+            # Only append new tokens for sequences that haven't completed
+            # For completed sequences, replace new token with EOS and let the
+            # tokenizer handle it
+            if eos_token_id is not None:
+                not_completed = not_completed & (idx_next[:, -1] != eos_token_id)
+                update_mask = not_completed.unsqueeze(-1)
+                idx_next = torch.where(
+                    update_mask, idx_next, torch.full_like(idx_next, eos_token_id)
+                )
+
             # append sampled index to the running sequence
             idx = torch.cat((idx, idx_next), dim=1)
-
-            # Check if EOS token was generated
-            if eos_token_id is not None and (idx_next == eos_token_id).any():
-                break
 
         return idx
 

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -407,6 +407,11 @@ class Llama(nn.Module):
         the sequence max_new_tokens times, feeding the predictions back into the model each time.
         Most likely you'll want to make sure to be in model.eval() mode of operation for this.
         """
+        # Keep track of whether input was 1D and ensure input has batch dimension
+        is_1d = idx.dim() == 1
+        if is_1d:
+            idx = idx.unsqueeze(0)
+
         # Initialize not_completed mask for the batch
         batch_size = idx.size(0)
         not_completed = torch.ones(batch_size, dtype=torch.bool, device=idx.device)
@@ -450,6 +455,10 @@ class Llama(nn.Module):
 
             # append sampled index to the running sequence
             idx = torch.cat((idx, idx_next), dim=1)
+
+        # Remove batch dimension if input was 1D
+        if is_1d:
+            idx = idx.squeeze(0)
 
         return idx
 

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -400,6 +400,7 @@ class Llama(nn.Module):
         max_new_tokens: int,
         temperature=1.0,
         top_k: int | None = None,
+        eos_token_id: int | None = None,  # Add EOS token parameter
     ) -> Float[Tensor, "... pos"]:
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (b,t)) and complete
@@ -423,8 +424,12 @@ class Llama(nn.Module):
             probs = F.softmax(logits, dim=-1)
             # sample from the distribution
             idx_next = torch.multinomial(probs, num_samples=1)
-            # append sampled index to the running sequence and continue
+            # append sampled index to the running sequence
             idx = torch.cat((idx, idx_next), dim=1)
+
+            # Check if EOS token was generated
+            if eos_token_id is not None and (idx_next == eos_token_id).any():
+                break
 
         return idx
 


### PR DESCRIPTION
## Description
Added eos_token_id argument for generate method of Llama implementation. Now the generation stops when it encounters the eos_token_id

## Related Issue
Solves the issue #23 

## Motivation and Context
Without this, the generate only stops after hitting the max_token limit which produces incoherent sentences

## How Has This Been Tested?
Test script has been added to test_llama_implementation.py to test the generate method using dummy data
