### PR TITLE
Have Llama.forward() return all logits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ check:
 
 .PHONY: test
 test:
-	python -m pytest
+	python -m pytest tests/
 
 .PHONY: test-all
 test-all:
-	python -m pytest --runslow
+	python -m pytest --runslow tests/

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -325,17 +325,14 @@ class Llama(nn.Module):
             x = block(x)
         x = self.transformer.rms_f(x)
 
+        logits = self.lm_head(x)
+        loss = None
         if targets is not None:
             # if we are given some desired targets also calculate the loss
-            logits = self.lm_head(x)
             targets = targets.long()
             loss = F.cross_entropy(
                 logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1
             )
-        else:
-            # inference-time mini-optimization: only forward the lm_head on the very last position
-            logits = self.lm_head(x[:, [-1], :])  # note: using list [-1] to preserve the time dim
-            loss = None
 
         # there are performance reasons why not returning logits is prudent, if not needed
         if not return_logits:

--- a/tests/test_llama_implementation.py
+++ b/tests/test_llama_implementation.py
@@ -108,7 +108,7 @@ def test_local_pt_model_loading() -> None:
             loaded_output, _ = loaded_model(dummy_input)
 
             torch.testing.assert_close(original_output, loaded_output)
-            assert original_output.shape == (1, 1, config.vocab_size)
+            assert original_output.shape == loaded_output.shape
 
 
 def test_generation_with_eos_token_id() -> None:


### PR DESCRIPTION
## Description
Changes the Llama.forward() implementation to always return logits, even when `targets` is not passed.

This will make generation less efficient when using the standard forward function, but I don't expect this to be very costly for our purposes compared to the benefit of getting the logits out.

If it does make a meaningful difference to typical inference usage, we can add a separate flag to the forward function to handle the more optimized version. I didn't want to complicate things for now if it's not needed.

## Motivation and Context
When using this model, it's very inconvenient to not be able to get the logits of a forward pass when you don't pass the targets.

## Does this PR introduce a breaking change?
Yes. Llama.forward will now return a different shaped tensor.
