### PR TITLE
Converting the custom implementation to HF implementation

### DIFF
--- a/tests/test_llama_implementation.py
+++ b/tests/test_llama_implementation.py
@@ -70,8 +70,10 @@ def test_rotary_embedding_implementation() -> None:
     custom_cos = custom_implementation.rotary_cos[position_ids].to(q_custom.dtype)
     custom_sin = custom_implementation.rotary_sin[position_ids].to(q_custom.dtype)
 
-    q_custom_rot, k_custom_rot = custom_implementation.apply_rotary_pos_emb(q_custom, k_custom, custom_cos, custom_sin)
-    
+    q_custom_rot, k_custom_rot = custom_implementation.apply_rotary_pos_emb(
+        q_custom, k_custom, custom_cos, custom_sin
+    )
+
     torch.testing.assert_close(
         q_hf_rot, q_custom_rot, msg="Rotated queries don't match between implementation"
     )

--- a/tests/test_llama_implementation.py
+++ b/tests/test_llama_implementation.py
@@ -67,9 +67,11 @@ def test_rotary_embedding_implementation() -> None:
     q_custom = q_hf.detach().clone()
     k_custom = k_hf.detach().clone()
 
-    q_custom_rot = custom_implementation.apply_rotary(q_custom)
-    k_custom_rot = custom_implementation.apply_rotary(k_custom)
+    custom_cos = custom_implementation.rotary_cos[position_ids].to(q_custom.dtype)
+    custom_sin = custom_implementation.rotary_sin[position_ids].to(q_custom.dtype)
 
+    q_custom_rot, k_custom_rot = custom_implementation.apply_rotary_pos_emb(q_custom, k_custom, custom_cos, custom_sin)
+    
     torch.testing.assert_close(
         q_hf_rot, q_custom_rot, msg="Rotated queries don't match between implementation"
     )


### PR DESCRIPTION
…

## Description
Changed the conversion script - fixed the generate function to e coherent results

## Motivation and Context
Conversion of custom impleemntation to HF implementation: The logits were rightly produced and passed the assertion but the generation was incoherent in HF one. Fixed it by adding the `do_sample = True` argument.

## How Has This Been Tested?
There is a single assertion statement but this script is only for internal use. The testing will be handled when merging with the main.

## Does this PR introduce a breaking change?
No