### PR TITLE
Add script for converting to a HF model

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -38,6 +38,6 @@ jobs:
     - name: Run ruff format
       run: |
         ruff format .
-    # - name: Run tests
-    #   run: |
-    #     python -m pytest --runslow --durations=10
+    - name: Run tests
+      run: |
+        python -m pytest --runslow --durations=10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Training of small LM models for SimpleStories"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "torch<2.6.0",
+    "torch>=2.6",
     "torchvision",
     "pydantic",
     "wandb",

--- a/simple_stories_train/convert_to_hf.py
+++ b/simple_stories_train/convert_to_hf.py
@@ -1,0 +1,107 @@
+"""
+This script demonstrates how to convert our custom model to a HuggingFace-compatible model.
+"""
+
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from simple_stories_train.models.llama import Llama
+from simple_stories_train.models.model_configs import MODEL_CONFIGS
+
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportIndexIssue=false
+
+
+def convert_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
+    """Convert Llama model to HuggingFace format.
+
+    Args:
+        custom_model: The custom Llama model to convert
+
+    Returns:
+        The converted HuggingFace model
+    """
+    model_config = custom_model.config
+
+    # Create a matching HuggingFace configuration
+    hf_config = LlamaConfig(
+        vocab_size=model_config.vocab_size,
+        hidden_size=model_config.n_embd,
+        intermediate_size=model_config.n_intermediate,
+        num_hidden_layers=model_config.n_layer,
+        num_attention_heads=model_config.n_head,
+        num_key_value_heads=model_config.n_key_value_heads,
+        hidden_act="silu",
+        max_position_embeddings=2048,
+        rms_norm_eps=model_config.rms_norm_eps,
+        tie_word_embeddings=True,
+    )
+
+    hf_model = LlamaForCausalLM(hf_config)
+
+    hf_model.model.embed_tokens.weight.data = custom_model.transformer.wte.weight.data
+
+    for i in range(model_config.n_layer):
+        # RMSNorm 1
+        hf_model.model.layers[i].input_layernorm.weight.data = custom_model.transformer.h[
+            i
+        ].rms_1.weight.data
+
+        # Attention weights
+        # Query projection
+        hf_model.model.layers[i].self_attn.q_proj.weight.data = custom_model.transformer.h[
+            i
+        ].attn.q_attn.weight.data
+
+        # Key and Value are combined in your model but separate in HF model
+        kv_weight = custom_model.transformer.h[i].attn.kv_attn.weight.data
+        kv_dim = kv_weight.shape[0] // 2
+
+        # Split KV weights for HF model
+        hf_model.model.layers[i].self_attn.k_proj.weight.data = kv_weight[:kv_dim, :]
+        hf_model.model.layers[i].self_attn.v_proj.weight.data = kv_weight[kv_dim:, :]
+
+        # Output projection
+        hf_model.model.layers[i].self_attn.o_proj.weight.data = custom_model.transformer.h[
+            i
+        ].attn.c_proj.weight.data
+
+        # RMSNorm 2
+        hf_model.model.layers[i].post_attention_layernorm.weight.data = custom_model.transformer.h[
+            i
+        ].rms_2.weight.data
+
+        # MLP layers
+        hf_model.model.layers[i].mlp.gate_proj.weight.data = custom_model.transformer.h[
+            i
+        ].mlp.gate_proj.weight.data
+        hf_model.model.layers[i].mlp.up_proj.weight.data = custom_model.transformer.h[
+            i
+        ].mlp.up_proj.weight.data
+        hf_model.model.layers[i].mlp.down_proj.weight.data = custom_model.transformer.h[
+            i
+        ].mlp.down_proj.weight.data
+
+    # 3. Final layer norm
+    hf_model.model.norm.weight.data = custom_model.transformer.rms_f.weight.data
+
+    # 4. LM head
+    hf_model.lm_head.weight.data = custom_model.lm_head.weight.data
+
+    # Set model to eval mode
+    hf_model.eval()
+
+    return hf_model
+
+
+if __name__ == "__main__":
+    # Example usage: Load a custom model and convert it
+    model_size = "1.25M"  # Change this to convert different model sizes
+    model_config = MODEL_CONFIGS[model_size]
+    custom_model = Llama.from_pretrained(f"SimpleStories/SimpleStories-{model_size}", model_config)
+    custom_model.eval()
+
+    # Convert the model
+    hf_model = convert_model_to_hf(custom_model)
+
+    # Uncomment to save the converted model
+    # hf_model.save_pretrained(f"converted_hf_model_{model_size}")

--- a/simple_stories_train/convert_to_hf.py
+++ b/simple_stories_train/convert_to_hf.py
@@ -11,7 +11,7 @@ from simple_stories_train.models.model_configs import MODEL_CONFIGS
 # pyright: reportIndexIssue=false
 
 
-def convert_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
+def convert_llama_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
     """Convert Llama model to HuggingFace format.
 
     Args:
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     custom_model.eval()
 
     # Convert the model
-    hf_model = convert_model_to_hf(custom_model)
+    hf_model = convert_llama_model_to_hf(custom_model)
 
     # Uncomment to save the converted model
     # hf_model.save_pretrained(f"converted_hf_model_{model_size}")

--- a/simple_stories_train/convert_to_hf.py
+++ b/simple_stories_train/convert_to_hf.py
@@ -2,7 +2,8 @@
 This script demonstrates how to convert our custom model to a HuggingFace-compatible model.
 """
 
-from transformers import LlamaConfig, LlamaForCausalLM
+from transformers import LlamaConfig as HFLlamaConfig
+from transformers import LlamaForCausalLM
 
 from simple_stories_train.models.llama import Llama
 from simple_stories_train.models.model_configs import MODEL_CONFIGS
@@ -11,7 +12,7 @@ from simple_stories_train.models.model_configs import MODEL_CONFIGS
 # pyright: reportIndexIssue=false
 
 
-def convert_llama_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
+def convert_llama_to_llama_for_causal_lm(custom_model: Llama) -> LlamaForCausalLM:
     """Convert Llama model to HuggingFace format.
 
     Args:
@@ -23,7 +24,7 @@ def convert_llama_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
     model_config = custom_model.config
 
     # Create a matching HuggingFace configuration
-    hf_config = LlamaConfig(
+    hf_config = HFLlamaConfig(
         vocab_size=model_config.vocab_size,
         hidden_size=model_config.n_embd,
         intermediate_size=model_config.n_intermediate,
@@ -101,7 +102,7 @@ if __name__ == "__main__":
     custom_model.eval()
 
     # Convert the model
-    hf_model = convert_llama_model_to_hf(custom_model)
+    hf_model = convert_llama_to_llama_for_causal_lm(custom_model)
 
     # Uncomment to save the converted model
     # hf_model.save_pretrained(f"converted_hf_model_{model_size}")

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -1,6 +1,7 @@
 import inspect
 import math
 import os
+from typing import cast
 
 import torch
 import torch.nn as nn
@@ -13,6 +14,8 @@ from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.nn import functional as F
 
 from simple_stories_train.utils import print0
+
+# pyright: reportAttributeAccessIssue=false
 
 
 class LlamaConfig(BaseModel):
@@ -206,8 +209,8 @@ class CausalSelfAttention(nn.Module):
 
         position_ids = position_ids.clamp(max=self.n_ctx - 1)
 
-        cos = self.rotary_cos[position_ids].to(q.dtype)
-        sin = self.rotary_sin[position_ids].to(q.dtype)
+        cos = cast(Tensor, self.rotary_cos)[position_ids].to(q.dtype)
+        sin = cast(Tensor, self.rotary_sin)[position_ids].to(q.dtype)
 
         q, k = self.apply_rotary_pos_emb(q, k, cos, sin)
 
@@ -223,7 +226,7 @@ class CausalSelfAttention(nn.Module):
         else:
             # Manual attention calculation
             att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
-            att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
+            att = att.masked_fill(cast(Tensor, self.bias)[:, :, :T, :T] == 0, float("-inf"))
             att = F.softmax(att, dim=-1)
             y = att @ v  # (B, n_head, T, head_dim)
 
@@ -325,11 +328,11 @@ class Llama(nn.Module):
         assert t <= self.config.block_size, (
             f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
         )
-        tok_emb = self.transformer.wte(idx)
+        tok_emb = self.transformer.wte(idx)  # pyright: ignore[reportCallIssue]
         x = tok_emb
-        for block in self.transformer.h:
+        for block in self.transformer.h:  # pyright: ignore[reportGeneralTypeIssues]
             x = block(x)
-        x = self.transformer.rms_f(x)
+        x = self.transformer.rms_f(x)  # pyright: ignore[reportCallIssue]
         logits = self.lm_head(x)
         loss = None
         if targets is not None:
@@ -383,7 +386,7 @@ class Llama(nn.Module):
         model.load_state_dict(state_dict, strict=False)
 
         # Regenerate rotary_sin and rotary_cos for each attention layer
-        for layer_idx, block in enumerate(model.transformer.h):
+        for layer_idx, block in enumerate(model.transformer.h):  # pyright: ignore[reportArgumentType]
             attn = block.attn
             sin, cos = attn.calculate_sin_cos_rotary(
                 rotary_dim=attn.rotary_dim,

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -34,6 +34,7 @@ class LlamaConfig(BaseModel):
     )  # Note that llama 3.1 n_key_value_heads does not scale with n_heads
     use_grouped_query_attention: bool = True
     flash_attention: bool = True
+    rms_norm_eps: float = 1e-6
 
 
 class CausalSelfAttention(nn.Module):
@@ -246,7 +247,7 @@ class SwiGLUMLP(nn.Module):
 
 
 class LlamaRMSNorm(nn.Module):
-    def __init__(self, hidden_size: int, eps: float = 1e-6):
+    def __init__(self, hidden_size: int, eps: float):
         """
         LlamaRMSNorm is equivalent to T5LayerNorm
         """
@@ -268,9 +269,9 @@ class LlamaRMSNorm(nn.Module):
 class Block(nn.Module):
     def __init__(self, config: LlamaConfig):
         super().__init__()
-        self.rms_1 = LlamaRMSNorm(config.n_embd)
+        self.rms_1 = LlamaRMSNorm(config.n_embd, eps=config.rms_norm_eps)
         self.attn = CausalSelfAttention(config)
-        self.rms_2 = LlamaRMSNorm(config.n_embd)
+        self.rms_2 = LlamaRMSNorm(config.n_embd, eps=config.rms_norm_eps)
         self.mlp = SwiGLUMLP(config)
 
     def forward(self, x: Float[Tensor, "... pos d_model"]) -> Float[Tensor, "... pos d_model"]:
@@ -287,7 +288,7 @@ class Llama(nn.Module):
             dict(
                 wte=nn.Embedding(config.vocab_size, config.n_embd),
                 h=nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
-                rms_f=LlamaRMSNorm(config.n_embd),
+                rms_f=LlamaRMSNorm(config.n_embd, eps=config.rms_norm_eps),
             )
         )
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -5,17 +5,82 @@ from typing import cast
 
 import torch
 import torch.nn as nn
-from huggingface_hub import hf_hub_download
 from jaxtyping import Float, Int
 from pydantic import BaseModel, ConfigDict
-from safetensors.torch import load_file
 from torch import Tensor
 from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.nn import functional as F
+from transformers import LlamaForCausalLM
 
 from simple_stories_train.utils import print0
 
 # pyright: reportAttributeAccessIssue=false
+
+
+def convert_llama_for_causal_lm_to_llama(hf_model: LlamaForCausalLM):
+    # Create a matching custom Llama configuration
+    hf_config = hf_model.config
+
+    model_config = LlamaConfig(
+        vocab_size=hf_config.vocab_size,
+        n_layer=hf_config.num_hidden_layers,
+        n_head=hf_config.num_attention_heads,
+        n_embd=hf_config.hidden_size,
+        n_intermediate=hf_config.intermediate_size,
+        rotary_dim=hf_config.hidden_size // hf_config.num_attention_heads,  # Assuming head_dim
+        n_key_value_heads=hf_config.num_key_value_heads,
+    )
+
+    model = Llama(model_config)
+
+    # Convert embeddings
+    model.transformer.wte.weight.data = hf_model.model.embed_tokens.weight.data
+
+    for i in range(hf_config.num_hidden_layers):
+        # RMSNorm 1
+        model.transformer.h[i].rms_1.weight.data = hf_model.model.layers[
+            i
+        ].input_layernorm.weight.data
+
+        # Attention weights
+        model.transformer.h[i].attn.q_attn.weight.data = hf_model.model.layers[
+            i
+        ].self_attn.q_proj.weight.data
+
+        # Key and Value projections - combine separate HF weights into single KV weight
+        k_weight = hf_model.model.layers[i].self_attn.k_proj.weight.data
+        v_weight = hf_model.model.layers[i].self_attn.v_proj.weight.data
+        kv_combined = torch.cat([k_weight, v_weight], dim=0)
+        model.transformer.h[i].attn.kv_attn.weight.data = kv_combined
+
+        # Output projection
+        model.transformer.h[i].attn.c_proj.weight.data = hf_model.model.layers[
+            i
+        ].self_attn.o_proj.weight.data
+
+        # RMSNorm 2
+        model.transformer.h[i].rms_2.weight.data = hf_model.model.layers[
+            i
+        ].post_attention_layernorm.weight.data
+
+        # MLP layers
+        model.transformer.h[i].mlp.gate_proj.weight.data = hf_model.model.layers[
+            i
+        ].mlp.gate_proj.weight.data
+        model.transformer.h[i].mlp.up_proj.weight.data = hf_model.model.layers[
+            i
+        ].mlp.up_proj.weight.data
+        model.transformer.h[i].mlp.down_proj.weight.data = hf_model.model.layers[
+            i
+        ].mlp.down_proj.weight.data
+
+    # Final layer norm
+    model.transformer.rms_f.weight.data = hf_model.model.norm.weight.data
+
+    # LM head
+    model.lm_head.weight.data = hf_model.lm_head.weight.data
+
+    return model
 
 
 class LlamaConfig(BaseModel):
@@ -348,56 +413,53 @@ class Llama(nn.Module):
     def from_pretrained(
         cls, model_path_or_id: str, config: LlamaConfig, strict: bool = True
     ) -> "Llama":
-        model = cls(config)
         is_local = os.path.exists(model_path_or_id)
+
         if is_local:
+            # Handle local files (existing logic for custom format)
             state_dict = torch.load(model_path_or_id, weights_only=True, map_location="cpu")
-        else:
-            try:
-                weights_path = hf_hub_download(
-                    repo_id=model_path_or_id, filename="model.safetensors"
+            model = cls(config)
+
+            state_dict = {k.replace("_orig_mod.", ""): v for k, v in state_dict.items()}
+
+            # Remove rotary_sin and rotary_cos from state_dict to regenerate them
+            keys_to_remove = [
+                k for k in state_dict if k.endswith("rotary_sin") or k.endswith("rotary_cos")
+            ]
+            for k in keys_to_remove:
+                state_dict.pop(k)
+
+            # Load state dict (ignoring rotary buffers)
+            model.load_state_dict(state_dict, strict=strict)
+
+            # Regenerate rotary_sin and rotary_cos for each attention layer
+            for _, block in enumerate(model.transformer.h):
+                attn = block.attn
+                sin, cos = attn.calculate_sin_cos_rotary(
+                    rotary_dim=attn.rotary_dim,
+                    n_ctx=attn.n_ctx,
+                    base=attn.rotary_base,
+                    dtype=attn.rotary_cos.dtype if hasattr(attn, "rotary_cos") else torch.float32,
                 )
-                state_dict = load_file(weights_path)
-                converted_state_dict = {}
-                for k, v in state_dict.items():
-                    k = k.replace("llama.", "")
-                    if k == "lm_head.weight":
-                        converted_state_dict["lm_head.weight"] = v
-                        converted_state_dict["transformer.wte.weight"] = v
-                    else:
-                        converted_state_dict[k] = v
-                state_dict = converted_state_dict
+                attn.register_buffer("rotary_sin", sin)
+                attn.register_buffer("rotary_cos", cos)
+
+            return model
+
+        else:
+            # Handle HuggingFace Hub models using the conversion function
+            try:
+                hf_model = LlamaForCausalLM.from_pretrained(model_path_or_id)
+
+                model = convert_llama_for_causal_lm_to_llama(hf_model)
+
+                return model
+
             except Exception as err:
                 raise ValueError(
                     f"Error loading model from HuggingFace Hub: {str(err)}. "
                     f"Please ensure the model path or ID '{model_path_or_id}' is correct."
                 ) from err
-
-        state_dict = {k.replace("_orig_mod.", ""): v for k, v in state_dict.items()}
-
-        # Remove rotary_sin and rotary_cos from state_dict to regenerate them
-        keys_to_remove = [
-            k for k in state_dict.keys() if k.endswith("rotary_sin") or k.endswith("rotary_cos")
-        ]
-        for k in keys_to_remove:
-            state_dict.pop(k)
-
-        # Load state dict (ignoring rotary buffers)
-        model.load_state_dict(state_dict, strict=False)
-
-        # Regenerate rotary_sin and rotary_cos for each attention layer
-        for layer_idx, block in enumerate(model.transformer.h):  # pyright: ignore[reportArgumentType]
-            attn = block.attn
-            sin, cos = attn.calculate_sin_cos_rotary(
-                rotary_dim=attn.rotary_dim,
-                n_ctx=attn.n_ctx,
-                base=attn.rotary_base,
-                dtype=attn.rotary_cos.dtype if hasattr(attn, "rotary_cos") else torch.float32,
-            )
-            attn.register_buffer("rotary_sin", sin)
-            attn.register_buffer("rotary_cos", cos)
-
-        return model
 
     def configure_optimizers(
         self,

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -14,7 +14,7 @@ from transformers import LlamaForCausalLM
 
 from simple_stories_train.utils import print0
 
-# pyright: reportAttributeAccessIssue=false
+# pyright: reportAttributeAccessIssue=false, reportIndexIssue=false
 
 
 def convert_llama_for_causal_lm_to_llama(hf_model: LlamaForCausalLM):
@@ -48,9 +48,10 @@ def convert_llama_for_causal_lm_to_llama(hf_model: LlamaForCausalLM):
         ].self_attn.q_proj.weight.data
 
         # Key and Value projections - combine separate HF weights into single KV weight
-        k_weight = hf_model.model.layers[i].self_attn.k_proj.weight.data
-        v_weight = hf_model.model.layers[i].self_attn.v_proj.weight.data
+        k_weight = cast(Tensor, hf_model.model.layers[i].self_attn.k_proj.weight.data)
+        v_weight = cast(Tensor, hf_model.model.layers[i].self_attn.v_proj.weight.data)
         kv_combined = torch.cat([k_weight, v_weight], dim=0)
+
         model.transformer.h[i].attn.kv_attn.weight.data = kv_combined
 
         # Output projection
@@ -433,7 +434,7 @@ class Llama(nn.Module):
             model.load_state_dict(state_dict, strict=strict)
 
             # Regenerate rotary_sin and rotary_cos for each attention layer
-            for _, block in enumerate(model.transformer.h):
+            for _, block in enumerate(model.transformer.h):  # type: ignore
                 attn = block.attn
                 sin, cos = attn.calculate_sin_cos_rotary(
                     rotary_dim=attn.rotary_dim,

--- a/simple_stories_train/train_llama.py
+++ b/simple_stories_train/train_llama.py
@@ -265,6 +265,7 @@ def main(config_path_or_obj: Path | str | Config | None = None, **kwargs: Any) -
         model: nn.Module = DDP(model, device_ids=[ddp_local_rank])
     raw_model = model.module if ddp else model  # always contains the "raw" unwrapped model
 
+    assert isinstance(raw_model, Llama)
     # init the optimizer
     optimizer = raw_model.configure_optimizers(
         weight_decay=config.weight_decay,

--- a/simple_stories_train/utils.py
+++ b/simple_stories_train/utils.py
@@ -40,7 +40,9 @@ def save_model(
     save_dir: Path, model: nn.Module, step: int, wandb_project: str | None = None
 ) -> None:
     # Get the underlying model if it's DDP-wrapped
-    state_dict = model.module.state_dict() if hasattr(model, "module") else model.state_dict()
+    state_dict = (
+        model.module.state_dict() if hasattr(model, "module") else model.state_dict()  # pyright: ignore[reportAttributeAccessIssue]
+    )
 
     model_file = save_dir / f"model_step_{step}.pt"
     torch.save(state_dict, model_file)

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -1,0 +1,62 @@
+"""
+Test script for custom to HuggingFace model conversion.
+"""
+
+import pytest
+import torch
+from tokenizers import Tokenizer
+from transformers import AutoTokenizer
+
+from simple_stories_train.convert_to_hf import convert_model_to_hf
+from simple_stories_train.models.llama import Llama
+from simple_stories_train.models.model_configs import MODEL_CONFIGS
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
+@torch.inference_mode()
+def test_convert_model_to_hf(
+    model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
+) -> None:
+    """Test the conversion from custom model to HuggingFace format.
+
+    Args:
+        model_size: Size of the model to test
+        tokenizer_path: Path to the custom tokenizer
+    """
+
+    # Load the custom model
+    model_config = MODEL_CONFIGS[model_size]
+    custom_model = Llama.from_pretrained(f"SimpleStories/SimpleStories-{model_size}", model_config)
+    custom_model.eval()
+
+    # Convert the model
+    hf_model = convert_model_to_hf(custom_model)
+
+    # Load custom tokenizer
+    custom_tokenizer: Tokenizer = Tokenizer.from_file(tokenizer_path)
+
+    # Load HF tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(f"SimpleStories/SimpleStories-{model_size}")
+    prompt = "The curious cat looked at the"
+
+    # Input using HF tokenizer
+    hf_inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
+
+    # Input using custom tokenizer
+    encoding = custom_tokenizer.encode(prompt)
+    custom_inputs = torch.tensor([encoding.ids], dtype=torch.long)  # Adding batch dimension with []
+
+    # Test with HF tokenizer inputs
+    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits
+    custom_logits = custom_model.forward(idx=hf_inputs.input_ids)[0]
+
+    # Assert logits are the same
+    torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
+
+    # Test with custom tokenizer inputs
+    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # pyright: ignore[reportArgumentType]
+    custom_logits = custom_model.forward(idx=custom_inputs)[0]
+
+    # Assert logits are the same
+    torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -7,7 +7,7 @@ import torch
 from tokenizers import Tokenizer
 from transformers import AutoTokenizer
 
-from simple_stories_train.convert_to_hf import convert_model_to_hf
+from simple_stories_train.convert_to_hf import convert_llama_model_to_hf
 from simple_stories_train.models.llama import Llama
 from simple_stories_train.models.model_configs import MODEL_CONFIGS
 
@@ -15,10 +15,10 @@ from simple_stories_train.models.model_configs import MODEL_CONFIGS
 @pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
-def test_convert_model_to_hf(
+def test_convert_llama_model_to_hf(
     model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
 ) -> None:
-    """Test the conversion from custom model to HuggingFace format.
+    """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
 
     Args:
         model_size: Size of the model to test
@@ -31,7 +31,7 @@ def test_convert_model_to_hf(
     custom_model.eval()
 
     # Convert the model
-    hf_model = convert_model_to_hf(custom_model)
+    hf_model = convert_llama_model_to_hf(custom_model)
 
     # Load custom tokenizer
     custom_tokenizer: Tokenizer = Tokenizer.from_file(tokenizer_path)

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -68,7 +68,12 @@ def test_convert_llama_to_llama_for_causal_lm(
 def test_convert_llama_for_causal_lm_to_llama(
     model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
 ) -> None:
-    """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
+    """Test the conversion from HuggingFace LlamaForCausalLM to custom llama model.
+
+    This test validates that:
+    1. HuggingFace pretrained models can be loaded successfully and ensures backward compatibility
+    2. The conversion produces logits identical to the original HuggingFace model
+    3. Both HuggingFace and custom tokenizers produce equivalent results
 
     Args:
         model_size: Size of the model to test

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -5,17 +5,16 @@ Test script for custom to HuggingFace model conversion.
 import pytest
 import torch
 from tokenizers import Tokenizer
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, LlamaForCausalLM
 
-from simple_stories_train.convert_to_hf import convert_llama_model_to_hf
-from simple_stories_train.models.llama import Llama
+from simple_stories_train.convert_to_hf import convert_llama_to_llama_for_causal_lm
+from simple_stories_train.models.llama import Llama, convert_llama_for_causal_lm_to_llama
 from simple_stories_train.models.model_configs import MODEL_CONFIGS
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
-def test_convert_llama_model_to_hf(
+def test_convert_llama_to_llama_for_causal_lm(
     model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
 ) -> None:
     """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
@@ -27,11 +26,59 @@ def test_convert_llama_model_to_hf(
 
     # Load the custom model
     model_config = MODEL_CONFIGS[model_size]
-    custom_model = Llama.from_pretrained(f"SimpleStories/SimpleStories-{model_size}", model_config)
+    custom_model = Llama(model_config)
     custom_model.eval()
 
     # Convert the model
-    hf_model = convert_llama_model_to_hf(custom_model)
+    hf_model = convert_llama_to_llama_for_causal_lm(custom_model)
+
+    # Load custom tokenizer
+    custom_tokenizer: Tokenizer = Tokenizer.from_file(tokenizer_path)
+
+    # Load HF tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(f"SimpleStories/SimpleStories-{model_size}")
+
+    prompt = "The curious cat looked at the"
+
+    # Input using HF tokenizer
+    hf_inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
+
+    # Input using custom tokenizer
+    encoding = custom_tokenizer.encode(prompt)
+    custom_inputs = torch.tensor([encoding.ids], dtype=torch.long)  # Adding batch dimension with []
+
+    # Test with HF tokenizer inputs
+    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits  # type: ignore
+    custom_logits = custom_model.forward(idx=hf_inputs.input_ids)[0]
+
+    # Assert logits are the same
+    torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
+
+    # Test with custom tokenizer inputs
+    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # type: ignore
+    custom_logits = custom_model.forward(idx=custom_inputs)[0]
+
+    # Assert logits are the same
+    torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
+@torch.inference_mode()
+def test_convert_llama_for_causal_lm_to_llama(
+    model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
+) -> None:
+    """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
+
+    Args:
+        model_size: Size of the model to test
+        tokenizer_path: Path to the custom tokenizer
+    """
+
+    # Load the custom model
+    hf_model = LlamaForCausalLM.from_pretrained(f"SimpleStories/SimpleStories-{model_size}")
+
+    # Convert the model
+    custom_model = convert_llama_for_causal_lm_to_llama(hf_model)
 
     # Load custom tokenizer
     custom_tokenizer: Tokenizer = Tokenizer.from_file(tokenizer_path)
@@ -48,14 +95,14 @@ def test_convert_llama_model_to_hf(
     custom_inputs = torch.tensor([encoding.ids], dtype=torch.long)  # Adding batch dimension with []
 
     # Test with HF tokenizer inputs
-    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits
+    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits  # type: ignore
     custom_logits = custom_model.forward(idx=hf_inputs.input_ids)[0]
 
     # Assert logits are the same
     torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
 
     # Test with custom tokenizer inputs
-    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # pyright: ignore[reportArgumentType]
+    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # type: ignore
     custom_logits = custom_model.forward(idx=custom_inputs)[0]
 
     # Assert logits are the same

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -62,6 +62,7 @@ def test_convert_llama_to_llama_for_causal_lm(
     torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
 def test_convert_llama_for_causal_lm_to_llama(

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -62,7 +62,6 @@ def test_convert_llama_to_llama_for_causal_lm(
     torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
 def test_convert_llama_for_causal_lm_to_llama(

--- a/tests/test_llama_implementation.py
+++ b/tests/test_llama_implementation.py
@@ -1,7 +1,9 @@
 import tempfile
 from pathlib import Path
+from typing import cast
 
 import torch
+from torch import Tensor
 from transformers import LlamaConfig as HFLlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding, apply_rotary_pos_emb
 
@@ -67,8 +69,8 @@ def test_rotary_embedding_implementation() -> None:
     q_custom = q_hf.detach().clone()
     k_custom = k_hf.detach().clone()
 
-    custom_cos = custom_implementation.rotary_cos[position_ids].to(q_custom.dtype)
-    custom_sin = custom_implementation.rotary_sin[position_ids].to(q_custom.dtype)
+    custom_cos = cast(Tensor, custom_implementation.rotary_cos)[position_ids].to(q_custom.dtype)
+    custom_sin = cast(Tensor, custom_implementation.rotary_sin)[position_ids].to(q_custom.dtype)
 
     q_custom_rot, k_custom_rot = custom_implementation.apply_rotary_pos_emb(
         q_custom, k_custom, custom_cos, custom_sin


### PR DESCRIPTION
## Description
TODO:
- [ ] Script for uploading a trained model to HF. It should first convert to hf then upload. May require the user to have environment variables to authenticate with HF.


- Adds convert_to_hf.py which contains `convert_llama_model_to_hf` for converting our custom Llama models to a HF LlamaForCausalLM model.
- Tests that the above works for our canonical runs

### Misc changes separate to main thrust of this PR:
- Adds `rms_norm_eps: float = 1e-6` to the config. Without this, we have to hardcode 1e-6 when converting to a HF model, which is dangerous.
- Re-enable tests in CI
- Fix all linting errors.

## Related Issue
Closes #35

## Motivation and Context
Our models are hosted on HF, but we don't have code to convert our LLama models to HF models.

## How Has This Been Tested?
Added tests/test_hf_compatibility which tests that each of our canonical models can be converted and produce the same logits on the same inputs (with both the custom and hf tokenizers).

## Does this PR introduce a breaking change?
No
