### PR TITLE
Added conversion scripts and corresponding tests

### DIFF
--- a/simple_stories_train/convert_to_hf.py
+++ b/simple_stories_train/convert_to_hf.py
@@ -2,7 +2,8 @@
 This script demonstrates how to convert our custom model to a HuggingFace-compatible model.
 """
 
-from transformers import LlamaConfig, LlamaForCausalLM
+from transformers import LlamaConfig as HFLlamaConfig
+from transformers import LlamaForCausalLM
 
 from simple_stories_train.models.llama import Llama
 from simple_stories_train.models.model_configs import MODEL_CONFIGS
@@ -11,7 +12,7 @@ from simple_stories_train.models.model_configs import MODEL_CONFIGS
 # pyright: reportIndexIssue=false
 
 
-def convert_llama_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
+def convert_llama_to_llama_for_causal_lm(custom_model: Llama) -> LlamaForCausalLM:
     """Convert Llama model to HuggingFace format.
 
     Args:
@@ -23,7 +24,7 @@ def convert_llama_model_to_hf(custom_model: Llama) -> LlamaForCausalLM:
     model_config = custom_model.config
 
     # Create a matching HuggingFace configuration
-    hf_config = LlamaConfig(
+    hf_config = HFLlamaConfig(
         vocab_size=model_config.vocab_size,
         hidden_size=model_config.n_embd,
         intermediate_size=model_config.n_intermediate,
@@ -101,7 +102,7 @@ if __name__ == "__main__":
     custom_model.eval()
 
     # Convert the model
-    hf_model = convert_llama_model_to_hf(custom_model)
+    hf_model = convert_llama_to_llama_for_causal_lm(custom_model)
 
     # Uncomment to save the converted model
     # hf_model.save_pretrained(f"converted_hf_model_{model_size}")

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -5,17 +5,82 @@ from typing import cast
 
 import torch
 import torch.nn as nn
-from huggingface_hub import hf_hub_download
 from jaxtyping import Float, Int
 from pydantic import BaseModel, ConfigDict
-from safetensors.torch import load_file
 from torch import Tensor
 from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.nn import functional as F
+from transformers import LlamaForCausalLM
 
 from simple_stories_train.utils import print0
 
 # pyright: reportAttributeAccessIssue=false
+
+
+def convert_llama_for_causal_lm_to_llama(hf_model: LlamaForCausalLM):
+    # Create a matching custom Llama configuration
+    hf_config = hf_model.config
+
+    model_config = LlamaConfig(
+        vocab_size=hf_config.vocab_size,
+        n_layer=hf_config.num_hidden_layers,
+        n_head=hf_config.num_attention_heads,
+        n_embd=hf_config.hidden_size,
+        n_intermediate=hf_config.intermediate_size,
+        rotary_dim=hf_config.hidden_size // hf_config.num_attention_heads,  # Assuming head_dim
+        n_key_value_heads=hf_config.num_key_value_heads,
+    )
+
+    model = Llama(model_config)
+
+    # Convert embeddings
+    model.transformer.wte.weight.data = hf_model.model.embed_tokens.weight.data
+
+    for i in range(hf_config.num_hidden_layers):
+        # RMSNorm 1
+        model.transformer.h[i].rms_1.weight.data = hf_model.model.layers[
+            i
+        ].input_layernorm.weight.data
+
+        # Attention weights
+        model.transformer.h[i].attn.q_attn.weight.data = hf_model.model.layers[
+            i
+        ].self_attn.q_proj.weight.data
+
+        # Key and Value projections - combine separate HF weights into single KV weight
+        k_weight = hf_model.model.layers[i].self_attn.k_proj.weight.data
+        v_weight = hf_model.model.layers[i].self_attn.v_proj.weight.data
+        kv_combined = torch.cat([k_weight, v_weight], dim=0)
+        model.transformer.h[i].attn.kv_attn.weight.data = kv_combined
+
+        # Output projection
+        model.transformer.h[i].attn.c_proj.weight.data = hf_model.model.layers[
+            i
+        ].self_attn.o_proj.weight.data
+
+        # RMSNorm 2
+        model.transformer.h[i].rms_2.weight.data = hf_model.model.layers[
+            i
+        ].post_attention_layernorm.weight.data
+
+        # MLP layers
+        model.transformer.h[i].mlp.gate_proj.weight.data = hf_model.model.layers[
+            i
+        ].mlp.gate_proj.weight.data
+        model.transformer.h[i].mlp.up_proj.weight.data = hf_model.model.layers[
+            i
+        ].mlp.up_proj.weight.data
+        model.transformer.h[i].mlp.down_proj.weight.data = hf_model.model.layers[
+            i
+        ].mlp.down_proj.weight.data
+
+    # Final layer norm
+    model.transformer.rms_f.weight.data = hf_model.model.norm.weight.data
+
+    # LM head
+    model.lm_head.weight.data = hf_model.lm_head.weight.data
+
+    return model
 
 
 class LlamaConfig(BaseModel):
@@ -348,56 +413,53 @@ class Llama(nn.Module):
     def from_pretrained(
         cls, model_path_or_id: str, config: LlamaConfig, strict: bool = True
     ) -> "Llama":
-        model = cls(config)
         is_local = os.path.exists(model_path_or_id)
+
         if is_local:
+            # Handle local files (existing logic for custom format)
             state_dict = torch.load(model_path_or_id, weights_only=True, map_location="cpu")
-        else:
-            try:
-                weights_path = hf_hub_download(
-                    repo_id=model_path_or_id, filename="model.safetensors"
+            model = cls(config)
+
+            state_dict = {k.replace("_orig_mod.", ""): v for k, v in state_dict.items()}
+
+            # Remove rotary_sin and rotary_cos from state_dict to regenerate them
+            keys_to_remove = [
+                k for k in state_dict if k.endswith("rotary_sin") or k.endswith("rotary_cos")
+            ]
+            for k in keys_to_remove:
+                state_dict.pop(k)
+
+            # Load state dict (ignoring rotary buffers)
+            model.load_state_dict(state_dict, strict=strict)
+
+            # Regenerate rotary_sin and rotary_cos for each attention layer
+            for _, block in enumerate(model.transformer.h):
+                attn = block.attn
+                sin, cos = attn.calculate_sin_cos_rotary(
+                    rotary_dim=attn.rotary_dim,
+                    n_ctx=attn.n_ctx,
+                    base=attn.rotary_base,
+                    dtype=attn.rotary_cos.dtype if hasattr(attn, "rotary_cos") else torch.float32,
                 )
-                state_dict = load_file(weights_path)
-                converted_state_dict = {}
-                for k, v in state_dict.items():
-                    k = k.replace("llama.", "")
-                    if k == "lm_head.weight":
-                        converted_state_dict["lm_head.weight"] = v
-                        converted_state_dict["transformer.wte.weight"] = v
-                    else:
-                        converted_state_dict[k] = v
-                state_dict = converted_state_dict
+                attn.register_buffer("rotary_sin", sin)
+                attn.register_buffer("rotary_cos", cos)
+
+            return model
+
+        else:
+            # Handle HuggingFace Hub models using the conversion function
+            try:
+                hf_model = LlamaForCausalLM.from_pretrained(model_path_or_id)
+
+                model = convert_llama_for_causal_lm_to_llama(hf_model)
+
+                return model
+
             except Exception as err:
                 raise ValueError(
                     f"Error loading model from HuggingFace Hub: {str(err)}. "
                     f"Please ensure the model path or ID '{model_path_or_id}' is correct."
                 ) from err
-
-        state_dict = {k.replace("_orig_mod.", ""): v for k, v in state_dict.items()}
-
-        # Remove rotary_sin and rotary_cos from state_dict to regenerate them
-        keys_to_remove = [
-            k for k in state_dict.keys() if k.endswith("rotary_sin") or k.endswith("rotary_cos")
-        ]
-        for k in keys_to_remove:
-            state_dict.pop(k)
-
-        # Load state dict (ignoring rotary buffers)
-        model.load_state_dict(state_dict, strict=False)
-
-        # Regenerate rotary_sin and rotary_cos for each attention layer
-        for layer_idx, block in enumerate(model.transformer.h):  # pyright: ignore[reportArgumentType]
-            attn = block.attn
-            sin, cos = attn.calculate_sin_cos_rotary(
-                rotary_dim=attn.rotary_dim,
-                n_ctx=attn.n_ctx,
-                base=attn.rotary_base,
-                dtype=attn.rotary_cos.dtype if hasattr(attn, "rotary_cos") else torch.float32,
-            )
-            attn.register_buffer("rotary_sin", sin)
-            attn.register_buffer("rotary_cos", cos)
-
-        return model
 
     def configure_optimizers(
         self,

--- a/simple_stories_train/models/llama.py
+++ b/simple_stories_train/models/llama.py
@@ -14,7 +14,7 @@ from transformers import LlamaForCausalLM
 
 from simple_stories_train.utils import print0
 
-# pyright: reportAttributeAccessIssue=false
+# pyright: reportAttributeAccessIssue=false, reportIndexIssue=false
 
 
 def convert_llama_for_causal_lm_to_llama(hf_model: LlamaForCausalLM):
@@ -48,9 +48,10 @@ def convert_llama_for_causal_lm_to_llama(hf_model: LlamaForCausalLM):
         ].self_attn.q_proj.weight.data
 
         # Key and Value projections - combine separate HF weights into single KV weight
-        k_weight = hf_model.model.layers[i].self_attn.k_proj.weight.data
-        v_weight = hf_model.model.layers[i].self_attn.v_proj.weight.data
+        k_weight = cast(Tensor, hf_model.model.layers[i].self_attn.k_proj.weight.data)
+        v_weight = cast(Tensor, hf_model.model.layers[i].self_attn.v_proj.weight.data)
         kv_combined = torch.cat([k_weight, v_weight], dim=0)
+
         model.transformer.h[i].attn.kv_attn.weight.data = kv_combined
 
         # Output projection
@@ -433,7 +434,7 @@ class Llama(nn.Module):
             model.load_state_dict(state_dict, strict=strict)
 
             # Regenerate rotary_sin and rotary_cos for each attention layer
-            for _, block in enumerate(model.transformer.h):
+            for _, block in enumerate(model.transformer.h):  # type: ignore
                 attn = block.attn
                 sin, cos = attn.calculate_sin_cos_rotary(
                     rotary_dim=attn.rotary_dim,

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -68,7 +68,12 @@ def test_convert_llama_to_llama_for_causal_lm(
 def test_convert_llama_for_causal_lm_to_llama(
     model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
 ) -> None:
-    """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
+    """Test the conversion from HuggingFace LlamaForCausalLM to custom llama model.
+
+    This test validates that:
+    1. HuggingFace pretrained models can be loaded successfully and ensures backward compatibility
+    2. The conversion produces logits identical to the original HuggingFace model
+    3. Both HuggingFace and custom tokenizers produce equivalent results
 
     Args:
         model_size: Size of the model to test

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -5,17 +5,16 @@ Test script for custom to HuggingFace model conversion.
 import pytest
 import torch
 from tokenizers import Tokenizer
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, LlamaForCausalLM
 
-from simple_stories_train.convert_to_hf import convert_llama_model_to_hf
-from simple_stories_train.models.llama import Llama
+from simple_stories_train.convert_to_hf import convert_llama_to_llama_for_causal_lm
+from simple_stories_train.models.llama import Llama, convert_llama_for_causal_lm_to_llama
 from simple_stories_train.models.model_configs import MODEL_CONFIGS
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
-def test_convert_llama_model_to_hf(
+def test_convert_llama_to_llama_for_causal_lm(
     model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
 ) -> None:
     """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
@@ -27,11 +26,59 @@ def test_convert_llama_model_to_hf(
 
     # Load the custom model
     model_config = MODEL_CONFIGS[model_size]
-    custom_model = Llama.from_pretrained(f"SimpleStories/SimpleStories-{model_size}", model_config)
+    custom_model = Llama(model_config)
     custom_model.eval()
 
     # Convert the model
-    hf_model = convert_llama_model_to_hf(custom_model)
+    hf_model = convert_llama_to_llama_for_causal_lm(custom_model)
+
+    # Load custom tokenizer
+    custom_tokenizer: Tokenizer = Tokenizer.from_file(tokenizer_path)
+
+    # Load HF tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(f"SimpleStories/SimpleStories-{model_size}")
+
+    prompt = "The curious cat looked at the"
+
+    # Input using HF tokenizer
+    hf_inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
+
+    # Input using custom tokenizer
+    encoding = custom_tokenizer.encode(prompt)
+    custom_inputs = torch.tensor([encoding.ids], dtype=torch.long)  # Adding batch dimension with []
+
+    # Test with HF tokenizer inputs
+    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits  # type: ignore
+    custom_logits = custom_model.forward(idx=hf_inputs.input_ids)[0]
+
+    # Assert logits are the same
+    torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
+
+    # Test with custom tokenizer inputs
+    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # type: ignore
+    custom_logits = custom_model.forward(idx=custom_inputs)[0]
+
+    # Assert logits are the same
+    torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
+@torch.inference_mode()
+def test_convert_llama_for_causal_lm_to_llama(
+    model_size: str, tokenizer_path: str = "simple_stories_train/tokenizer/simplestories-4096.json"
+) -> None:
+    """Test the conversion from custom llama model to a HuggingFace LlamaForCausalLM model.
+
+    Args:
+        model_size: Size of the model to test
+        tokenizer_path: Path to the custom tokenizer
+    """
+
+    # Load the custom model
+    hf_model = LlamaForCausalLM.from_pretrained(f"SimpleStories/SimpleStories-{model_size}")
+
+    # Convert the model
+    custom_model = convert_llama_for_causal_lm_to_llama(hf_model)
 
     # Load custom tokenizer
     custom_tokenizer: Tokenizer = Tokenizer.from_file(tokenizer_path)
@@ -48,14 +95,14 @@ def test_convert_llama_model_to_hf(
     custom_inputs = torch.tensor([encoding.ids], dtype=torch.long)  # Adding batch dimension with []
 
     # Test with HF tokenizer inputs
-    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits
+    hf_logits = hf_model.forward(input_ids=hf_inputs.input_ids).logits  # type: ignore
     custom_logits = custom_model.forward(idx=hf_inputs.input_ids)[0]
 
     # Assert logits are the same
     torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
 
     # Test with custom tokenizer inputs
-    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # pyright: ignore[reportArgumentType]
+    hf_logits = hf_model.forward(input_ids=custom_inputs).logits  # type: ignore
     custom_logits = custom_model.forward(idx=custom_inputs)[0]
 
     # Assert logits are the same

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -62,6 +62,7 @@ def test_convert_llama_to_llama_for_causal_lm(
     torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
 def test_convert_llama_for_causal_lm_to_llama(

--- a/tests/test_hf_compatibility.py
+++ b/tests/test_hf_compatibility.py
@@ -62,7 +62,6 @@ def test_convert_llama_to_llama_for_causal_lm(
     torch.testing.assert_close(hf_logits, custom_logits, rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("model_size", ["1.25M", "5M", "11M", "30M", "35M"])
 @torch.inference_mode()
 def test_convert_llama_for_causal_lm_to_llama(


### PR DESCRIPTION
## Description
Added the conversion script to and from CausalLlama of HF to our custom Llama. In `from_pretrained`, used this to download from HF and then convert into custom Llama

## Related Issue
Closes issue #38.  Addresses the issue #37. 

## Motivation and Context
While using `from_pretrained`, the models downloaded from huggingface has different keys than the custom Llama and needs an intermediate step of conversion. 

## How Has This Been Tested?
Two tests are in the file `test_hf_compatibility.py` to test both conversions with all model types.

## Does this PR introduce a breaking change?
No
